### PR TITLE
Add fail-on-warn flag to action

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -6,6 +6,9 @@ inputs:
   validationfile:
     description: "path to the YAML file containing schema, test relationships, assertions and expected relations"
     required: true
+  fail-on-warn:
+    description: "whether validation warnings should cause the validation to fail"
+    required: false
 runs:
   using: "docker"
   image: "Dockerfile"

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,2 +1,6 @@
 #/bin/bash
-/zed validate $INPUT_VALIDATIONFILE
+ARGS=""
+
+[[ $INPUT_FAIL_ON_WARN == "true" ]] && ARGS+=" --fail-on-warn"
+
+/zed validate $ARGS $INPUT_VALIDATIONFILE


### PR DESCRIPTION
## Description
We added a `--fail-on-warn` flag in authzed/zed#539 that's meant for use in CI. This adds it to the action so that it can be used in CI.

## Changes
* Add flag to the action and pass into entrypoint

## Testing
Review. Merge this and then try it out.