### PR TITLE
Add support for validating multiple schema files

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -9,7 +9,7 @@ jobs:
   test:
     runs-on: "ubuntu-latest"
     steps:
-      - uses: "actions/checkout@v2"
+      - uses: "actions/checkout@v6"
       - uses: "bewuethr/yamllint-action@v1.1.1"
         with:
           config-file: ".yamllint"

--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ steps:
 
 | Input | Description | Required |
 |-------|-------------|----------|
-| `validationfile` | Path to a single YAML file to validate | No* |
+| `validationfile` | Path to a single validation file | No* |
 | `validationfiles` | List of paths to validate (newline or comma separated, supports glob patterns including `**`) | No* |
 | `fail-on-warn` | Whether validation warnings should cause the validation to fail | No |
 

--- a/README.md
+++ b/README.md
@@ -16,6 +16,8 @@ A compatible file can be produced by downloading from the [Authzed Playground].
 
 ## Usage
 
+### Single file validation
+
 Add the following to any workflow:
 
 ```yaml
@@ -29,7 +31,53 @@ steps:
 > **Note:** The `actions/checkout` step is required before running this action.
 > Without it, your repository files won't be available and validation will fail with "no such file or directory".
 
-The `validationfile` path should be relative to the repository root.
+### Multiple files validation
+
+You can validate multiple files using the `validationfiles` input:
+
+```yaml
+steps:
+- uses: "actions/checkout@v4"
+- uses: "authzed/action-spicedb-validate@v1"
+  with:
+    validationfiles: |
+      schemas/schema1.zaml
+      schemas/schema2.zaml
+```
+
+Comma-separated values are also supported:
+
+```yaml
+steps:
+- uses: "actions/checkout@v4"
+- uses: "authzed/action-spicedb-validate@v1"
+  with:
+    validationfiles: "schemas/schema1.zaml, schemas/schema2.zaml"
+```
+
+You can also use glob patterns (including recursive `**` patterns):
+
+```yaml
+steps:
+- uses: "actions/checkout@v4"
+- uses: "authzed/action-spicedb-validate@v1"
+  with:
+    validationfiles: "schemas/**/*.zaml"
+```
+
+### Inputs
+
+| Input | Description | Required |
+|-------|-------------|----------|
+| `validationfile` | Path to a single YAML file to validate | No* |
+| `validationfiles` | List of paths to validate (newline or comma separated, supports glob patterns including `**`) | No* |
+| `fail-on-warn` | Whether validation warnings should cause the validation to fail | No |
+
+\* At least one of `validationfile` or `validationfiles` must be provided.
+
+The `validationfile`/`validationfiles` paths should be relative to the repository root.
+
+> **Note:** File paths with spaces are supported when using newline-separated literal paths or the single `validationfile` input. Glob patterns in paths with spaces may not expand correctly. Filenames containing literal glob characters (`*`, `?`, `[`) or commas must use the single `validationfile` input.
 
 See [test-schema.zaml] for an example of an input file.
 

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Add the following to any workflow:
 
 ```yaml
 steps:
-- uses: "actions/checkout@v4"
+- uses: "actions/checkout@v6"
 - uses: "authzed/action-spicedb-validate@v1"
   with:
     validationfile: "myschema.zaml"
@@ -37,7 +37,7 @@ You can validate multiple files using the `validationfiles` input:
 
 ```yaml
 steps:
-- uses: "actions/checkout@v4"
+- uses: "actions/checkout@v6"
 - uses: "authzed/action-spicedb-validate@v1"
   with:
     validationfiles: |
@@ -49,7 +49,7 @@ Comma-separated values are also supported:
 
 ```yaml
 steps:
-- uses: "actions/checkout@v4"
+- uses: "actions/checkout@v6"
 - uses: "authzed/action-spicedb-validate@v1"
   with:
     validationfiles: "schemas/schema1.zaml, schemas/schema2.zaml"
@@ -59,7 +59,7 @@ You can also use glob patterns (including recursive `**` patterns):
 
 ```yaml
 steps:
-- uses: "actions/checkout@v4"
+- uses: "actions/checkout@v6"
 - uses: "authzed/action-spicedb-validate@v1"
   with:
     validationfiles: "schemas/**/*.zaml"

--- a/action.yml
+++ b/action.yml
@@ -4,8 +4,11 @@ description: "Runs the `zed validate` command on the provided schema and test da
 author: "authzed"
 inputs:
   validationfile:
-    description: "path to the YAML file containing schema, test relationships, assertions and expected relations"
-    required: true
+    description: "path to the YAML file containing schema, test relationships, assertions and expected relations (for single file validation)"
+    required: false
+  validationfiles:
+    description: "list of paths to YAML files to validate (newline or comma separated, supports glob patterns)"
+    required: false
   fail-on-warn:
     description: "whether validation warnings should cause the validation to fail"
     required: false

--- a/action.yml
+++ b/action.yml
@@ -4,10 +4,10 @@ description: "Runs the `zed validate` command on the provided schema and test da
 author: "authzed"
 inputs:
   validationfile:
-    description: "path to the YAML file containing schema, test relationships, assertions and expected relations (for single file validation)"
+    description: "path to the validation file containing schema, test relationships, assertions and expected relations (for single file validation)"
     required: false
   validationfiles:
-    description: "list of paths to YAML files to validate (newline or comma separated, supports glob patterns)"
+    description: "list of paths to validation files (newline or comma separated, supports glob patterns)"
     required: false
   fail-on-warn:
     description: "whether validation warnings should cause the validation to fail"

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,6 +1,72 @@
-#/bin/bash
-ARGS=""
+#!/bin/bash
+set -e
 
+# Enable recursive globbing for ** patterns (bash 4+)
+# Guard for bash 3.x compatibility (e.g., macOS default)
+shopt -s nullglob
+shopt -s globstar 2>/dev/null || true
+
+ARGS=""
 [[ $INPUT_FAIL_ON_WARN == "true" ]] && ARGS+=" --fail-on-warn"
 
-/zed validate $ARGS $INPUT_VALIDATIONFILE
+# Collect all files to validate
+FILES=()
+HAD_INPUT=0
+
+# Handle single file input (backward compatibility)
+if [[ -n "$INPUT_VALIDATIONFILE" ]]; then
+    HAD_INPUT=1
+    FILES+=("$INPUT_VALIDATIONFILE")
+fi
+
+# Handle multiple files input
+if [[ -n "$INPUT_VALIDATIONFILES" ]]; then
+    HAD_INPUT=1
+    # Replace commas with newlines and process each entry
+    # Use printf instead of echo to avoid option interpretation
+    while IFS= read -r entry; do
+        # Trim leading/trailing whitespace without breaking spaces in paths
+        entry="${entry#"${entry%%[![:space:]]*}"}"
+        entry="${entry%"${entry##*[![:space:]]}"}"
+        [[ -z "$entry" ]] && continue
+        
+        # Check if entry contains glob pattern characters
+        if [[ "$entry" == *"*"* || "$entry" == *"?"* || "$entry" == *"["* ]]; then
+            # Expand glob pattern safely without eval (globstar enabled for ** support)
+            # Use an array assignment for safe glob expansion
+            expanded=()
+            # shellcheck disable=SC2206
+            expanded=($entry)
+            for file in "${expanded[@]}"; do
+                [[ -f "$file" ]] && FILES+=("$file")
+            done
+        else
+            FILES+=("$entry")
+        fi
+    done <<< "$(printf '%s\n' "$INPUT_VALIDATIONFILES" | tr ',' '\n')"
+fi
+
+# Check if we have any files to validate
+if [[ $HAD_INPUT -eq 0 ]]; then
+    echo "Error: No validation files provided. Set either 'validationfile' or 'validationfiles' input."
+    exit 1
+fi
+
+if [[ ${#FILES[@]} -eq 0 ]]; then
+    echo "Error: No files matched the provided patterns."
+    exit 1
+fi
+
+# Validate each file
+FAILED=0
+for file in "${FILES[@]}"; do
+    echo "Validating $file..."
+    # ARGS is intentionally unquoted for word splitting (may be empty or --fail-on-warn)
+    # Use -- to prevent filenames starting with - from being interpreted as options
+    # shellcheck disable=SC2086
+    if ! /zed validate $ARGS -- "$file"; then
+        FAILED=1
+    fi
+done
+
+exit $FAILED


### PR DESCRIPTION
## Description

Adds the ability to validate multiple schema files in a single action run. Previously, only one file could be validated at a time.

The new `validationfiles` input accepts:
- Newline-separated file paths
- Comma-separated file paths
- Glob patterns including recursive `**`

The existing `validationfile` input continues to work for backward compatibility.

## Changes

* Add new `validationfiles` input to `action.yml`
* Rewrite `entrypoint.sh` to handle multiple files and glob expansion
* Update README with usage examples

Fixes #6